### PR TITLE
Fix Json detector to ignore {} in strings

### DIFF
--- a/src/main/kotlin/com/jerryjeon/logjerry/detector/JsonDetector.kt
+++ b/src/main/kotlin/com/jerryjeon/logjerry/detector/JsonDetector.kt
@@ -14,19 +14,24 @@ class JsonDetector() : Detector<JsonDetection> {
         // Find bracket pairs, { } and check this is json or not
         val stack = ArrayDeque<Pair<Int, Char>>()
         val bracketRanges = mutableListOf<IntRange>()
+        var inString = false
         logStr.forEachIndexed { index, c ->
-            if (c == '{') stack.addLast(index to '{')
-            else if (c == '}') {
-                val lastOrNull = stack.lastOrNull() ?: return@forEachIndexed
-                if (lastOrNull.second == '{') {
-                    val (openIndex, _) = stack.removeLast()
-                    if (stack.isEmpty()) { // It's most outside part of bracket
-                        bracketRanges.add(openIndex..index)
+            if (c == '"' && (index == 0 || logStr[index - 1] != '\\')) {
+                inString = !inString
+            }
+            if (!inString) {
+                if (c == '{') stack.addLast(index to '{')
+                else if (c == '}') {
+                    val lastOrNull = stack.lastOrNull() ?: return@forEachIndexed
+                    if (lastOrNull.second == '{') {
+                        val (openIndex, _) = stack.removeLast()
+                        if (stack.isEmpty()) { // It's most outside part of bracket
+                            bracketRanges.add(openIndex..index)
+                        }
                     }
                 }
             }
         }
-
         if (bracketRanges.isEmpty()) return emptyList()
 
         val jsonList = bracketRanges.mapNotNull { range ->

--- a/src/test/kotlin/com/jerryjeon/logjerry/parse/JsonTest.kt
+++ b/src/test/kotlin/com/jerryjeon/logjerry/parse/JsonTest.kt
@@ -1,0 +1,18 @@
+package com.jerryjeon.logjerry.parse
+
+import com.jerryjeon.logjerry.detector.JsonDetector
+import com.jerryjeon.logjerry.log.Log
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldBeSingleton
+import org.junit.jupiter.api.Test
+
+internal class JsonTest {
+
+    @Test
+    fun `Parse Json with {} in strings correctly`() {
+        val parseResult = JsonDetector().detect(
+            "{\"Name\":\"The Only Road (feat. Danyka Nadeau)\",\"ImageBlurHashes\":{\"Primary\":{\"dd58848b72bc9a8968d76eece457cab8\":\"eMN,bzs.tl?u8_~U-;-;%Ls:pJM{D%MxkD-.t7jbo2oz.8s:V@t6tQ\",\"66e4be9e3be3d61d751a31e7dbe93f84\":\"e65:=*sn10ja-TNvw_PW:S35m}sU^4bG9^,?SMJ8ays.XkWpIqWV=w\"}}}",1
+        )
+        assert(parseResult.size == 1)
+    }
+}


### PR DESCRIPTION
Fix the detector to properly ignore the {} in strings and properly detect more JSON data.