### PR TITLE
Support CustomParser natively

### DIFF
--- a/src/main/kotlin/com/jerryjeon/logjerry/parse/CustomParser.kt
+++ b/src/main/kotlin/com/jerryjeon/logjerry/parse/CustomParser.kt
@@ -1,0 +1,13 @@
+package com.jerryjeon.logjerry.parse
+
+class CustomParser : LogParser {
+    override fun parse(rawLines: List<String>): ParseResult {
+        TODO("Not yet implemented")
+    }
+
+    companion object : ParserFactory {
+        override fun create(sample: String): LogParser? {
+            return null
+        }
+    }
+}

--- a/src/main/kotlin/com/jerryjeon/logjerry/source/SourceManager.kt
+++ b/src/main/kotlin/com/jerryjeon/logjerry/source/SourceManager.kt
@@ -51,7 +51,8 @@ class SourceManager(
 
     private fun chooseParser(lines: List<String>): LogParser {
         return lines.firstNotNullOfOrNull {
-            StudioLogcatBelowChipmunkParser.create(it)
+            CustomParser.create(it)
+                ?: StudioLogcatBelowChipmunkParser.create(it)
                 ?: StudioLogcatAboveDolphinParser.create(it)
         } ?: studioLogcatBelowChipmunkParser // TODO would be better if show failure message that the parser doesn't exist that can parse the content
     }


### PR DESCRIPTION
Simplify life for people using a CustomParser by having it already prepared and just having to maintain a single file without conflicts.