### PR TITLE
Fix startup window size

### DIFF
--- a/src/main/kotlin/com/jerryjeon/logjerry/Main.kt
+++ b/src/main/kotlin/com/jerryjeon/logjerry/Main.kt
@@ -220,10 +220,14 @@ fun main() = application {
     val shortcutDialogOpened = remember { mutableStateOf(false) }
     val tabManager = TabManager(preferences)
     val tabsState = tabManager.tabs.collectAsState()
+
+    val width = preferences.windowSizeWhenOpened?.width?.dp ?: Dp.Unspecified
+    val height = preferences.windowSizeWhenOpened?.height?.dp ?: Dp.Unspecified
+
     Window(
         title = "LogJerry",
         icon = painterResource("LogJerry.png"),
-        state = WindowState(width = 900.dp, height = 900.dp),
+        state = WindowState(width = width, height = height),
         onCloseRequest = ::exitApplication,
         onPreviewKeyEvent = { keyEvent ->
             if (keyEvent.isCtrlOrMetaPressed && keyEvent.key == Key.F && keyEvent.type == KeyEventType.KeyDown) {

--- a/src/main/kotlin/com/jerryjeon/logjerry/Main.kt
+++ b/src/main/kotlin/com/jerryjeon/logjerry/Main.kt
@@ -223,7 +223,7 @@ fun main() = application {
     Window(
         title = "LogJerry",
         icon = painterResource("LogJerry.png"),
-        state = WindowState(width = Dp.Unspecified, height = Dp.Unspecified),
+        state = WindowState(width = 900.dp, height = 900.dp),
         onCloseRequest = ::exitApplication,
         onPreviewKeyEvent = { keyEvent ->
             if (keyEvent.isCtrlOrMetaPressed && keyEvent.key == Key.F && keyEvent.type == KeyEventType.KeyDown) {

--- a/src/main/kotlin/com/jerryjeon/logjerry/preferences/Preferences.kt
+++ b/src/main/kotlin/com/jerryjeon/logjerry/preferences/Preferences.kt
@@ -15,6 +15,7 @@ import com.jerryjeon.logjerry.table.Header
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import kotlinx.serialization.json.decodeFromStream
 import java.io.File
 
@@ -42,6 +43,7 @@ data class Preferences(
     val showExceptionDetection: Boolean = true,
     val showInvalidSentences: Boolean = true,
     val jsonPreviewSize: Int = 20,
+    val windowSizeWhenOpened: WindowSize? = null, // (width, height), null to maximize
 ) {
 
     // TODO should be optimized
@@ -66,6 +68,7 @@ data class Preferences(
     }
 
     // These are not need to be here, but I don't want to create another class for this
+    @Transient
     val headerFlow = MutableStateFlow(
         try {
             Header.file.inputStream().use { PreferencesViewModel.json.decodeFromStream(it) }

--- a/src/main/kotlin/com/jerryjeon/logjerry/preferences/PreferencesView.kt
+++ b/src/main/kotlin/com/jerryjeon/logjerry/preferences/PreferencesView.kt
@@ -43,6 +43,12 @@ fun PreferencesView(
     val jsonPreviewSizeString by viewModel.jsonPreviewSizeString.collectAsState()
     val jsonPreviewSize by viewModel.jsonPreviewSize.collectAsState()
 
+    val maximizeWindow by viewModel.maximizeWindow.collectAsState()
+    val widthWhenOpenedString by viewModel.widthWhenOpenedString.collectAsState()
+    val widthWhenOpened by viewModel.widthWhenOpened.collectAsState()
+    val heightWhenOpenedString by viewModel.heightWhenOpenedString.collectAsState()
+    val heightWhenOpened by viewModel.heightWhenOpened.collectAsState()
+
     if (isOpen.value) {
         Window(
             state = WindowState(width = 1200.dp, height = 1200.dp),
@@ -85,6 +91,43 @@ fun PreferencesView(
                                 isError = jsonPreviewSize == null,
                                 keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Decimal)
                             )
+                        }
+                        Spacer(Modifier.height(8.dp))
+
+                        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.height(IntrinsicSize.Min)) {
+                            Text("Window size")
+                            Spacer(Modifier.width(4.dp))
+                            Divider(Modifier.width(1.dp).fillMaxHeight().alpha(0.5f))
+                            Spacer(Modifier.width(4.dp))
+                            Text("Maximize")
+                            Checkbox(maximizeWindow, onCheckedChange = viewModel::changeMaximizeWindow)
+                            Spacer(Modifier.width(4.dp))
+                            Divider(Modifier.width(1.dp).fillMaxHeight().alpha(0.5f))
+                            Spacer(Modifier.width(4.dp))
+                            Text("Width")
+                            Spacer(Modifier.width(4.dp))
+                            TextField(
+                                value = widthWhenOpenedString,
+                                onValueChange = viewModel::changeWidthWhenOpened,
+                                modifier = Modifier.width(120.dp),
+                                singleLine = true,
+                                isError = widthWhenOpened == null,
+                                enabled = !maximizeWindow,
+                                keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Decimal)
+                            )
+                            Spacer(Modifier.width(4.dp))
+                            Text("Height")
+                            Spacer(Modifier.width(4.dp))
+                            TextField(
+                                value = heightWhenOpenedString,
+                                onValueChange = viewModel::changeHeightWhenOpened,
+                                modifier = Modifier.width(120.dp),
+                                singleLine = true,
+                                isError = heightWhenOpened == null,
+                                enabled = !maximizeWindow,
+                                keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Decimal)
+                            )
+
                         }
 
                         Spacer(Modifier.height(8.dp))

--- a/src/main/kotlin/com/jerryjeon/logjerry/preferences/PreferencesViewModel.kt
+++ b/src/main/kotlin/com/jerryjeon/logjerry/preferences/PreferencesViewModel.kt
@@ -119,6 +119,27 @@ class PreferencesViewModel {
         this.jsonPreviewSizeString.value = jsonPreviewSize
     }
 
+    val maximizeWindow = MutableStateFlow(preferencesFlow.value.windowSizeWhenOpened == null)
+    fun changeMaximizeWindow(maximizeWindow: Boolean) {
+        this.maximizeWindow.value = maximizeWindow
+    }
+
+    val widthWhenOpenedString = MutableStateFlow(preferencesFlow.value.windowSizeWhenOpened?.width?.toString() ?: "900")
+    val widthWhenOpened = widthWhenOpenedString.map { it.toIntOrNull() }
+        .stateIn(preferenceScope, SharingStarted.Lazily, preferencesFlow.value.windowSizeWhenOpened?.width)
+
+    fun changeWidthWhenOpened(widthWhenOpened: String) {
+        this.widthWhenOpenedString.value = widthWhenOpened
+    }
+
+    val heightWhenOpenedString = MutableStateFlow(preferencesFlow.value.windowSizeWhenOpened?.height?.toString() ?: "900")
+    val heightWhenOpened = heightWhenOpenedString.map { it.toIntOrNull() }
+        .stateIn(preferenceScope, SharingStarted.Lazily, preferencesFlow.value.windowSizeWhenOpened?.height)
+
+    fun changeHeightWhenOpened(heightWhenOpened: String) {
+        this.heightWhenOpenedString.value = heightWhenOpened
+    }
+
     fun save() {
         val whiteSavingColors = whiteValidColorsByPriority.value
         val whiteSavingBackgroundColor = whiteBackgroundValidColor.value
@@ -133,6 +154,15 @@ class PreferencesViewModel {
         }
         val jsonPreviewSizeValue = jsonPreviewSize.value ?: return
 
+        val maximizeWindow = maximizeWindow.value
+        val windowSizeWhenOpened = if (maximizeWindow) {
+            null
+        } else {
+            val widthWhenOpened = widthWhenOpened.value ?: return
+            val heightWhenOpened = heightWhenOpened.value ?: return
+            WindowSize(widthWhenOpened, heightWhenOpened)
+        }
+
         preferencesFlow.value = preferencesFlow.value.copy(
             colorTheme = colorThemeFlow.value,
             lightColorByPriority = whiteSavingColors.mapValues { (_, color) -> color!! },
@@ -142,7 +172,10 @@ class PreferencesViewModel {
             showExceptionDetection = showExceptionDetection.value,
             showInvalidSentences = showInvalidSentences.value,
             jsonPreviewSize = jsonPreviewSizeValue,
+            windowSizeWhenOpened = windowSizeWhenOpened
         )
+
+        println("HMMMM? ${preferencesFlow.value}")
 
         Preferences.file.outputStream().use {
             json.encodeToStream(preferencesFlow.value, it)

--- a/src/main/kotlin/com/jerryjeon/logjerry/preferences/WindowSize.kt
+++ b/src/main/kotlin/com/jerryjeon/logjerry/preferences/WindowSize.kt
@@ -1,0 +1,10 @@
+package com.jerryjeon.logjerry.preferences
+
+import kotlinx.serialization.Serializable
+
+// null to maximize
+@Serializable
+data class WindowSize(
+    val width: Int,
+    val height: Int,
+)


### PR DESCRIPTION
On startup on Windows at least, Dp.Unspecified leads to a too large window that is annoying.