### PR TITLE
Fix proguard configuration for kotlinx.serialization

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,5 +45,8 @@ tasks {
 compose.desktop {
     application {
         mainClass = "com.jerryjeon.logjerry.MainKt"
+        buildTypes.release.proguard {
+            configurationFiles.from("proguard-rules.pro")
+        }
     }
 }

--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -1,0 +1,22 @@
+-keepattributes Annotation, InnerClasses
+-dontnote kotlinx.serialization.AnnotationsKt
+-dontnote kotlinx.serialization.SerializationKt
+
+# Keep Serializers
+
+-keep,includedescriptorclasses class com.jerryjeon.logjerry.**$$serializer { *; }
+-keepclassmembers class com.jerryjeon.logjerry.** {
+    *** Companion;
+}
+-keepclasseswithmembers class com.jerryjeon.logjerry.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# When kotlinx.serialization.json.JsonObjectSerializer occurs
+
+-keepclassmembers class kotlinx.serialization.json.** {
+    *** Companion;
+}
+-keepclasseswithmembers class kotlinx.serialization.json.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}


### PR DESCRIPTION
As per title when building MSI proguard is enabled but break the preferences.

This fixes it.