### PR TITLE
Improve filtering by properly cancelling outdated states

### DIFF
--- a/src/main/kotlin/com/jerryjeon/logjerry/detector/DetectorManager.kt
+++ b/src/main/kotlin/com/jerryjeon/logjerry/detector/DetectorManager.kt
@@ -38,7 +38,7 @@ class DetectorManager(preferences: Preferences) {
         .stateIn(detectionScope, SharingStarted.Lazily, emptyList())
 
     val detectorsFlow = combine(
-        keywordDetectionRequestFlow.debounce(100L), markDetectorFlow
+        keywordDetectionRequestFlow, markDetectorFlow
     ) { keywordDetectionRequest, markDetector ->
         when (keywordDetectionRequest) {
             is KeywordDetectionRequest.TurnedOn -> defaultDetectors + listOf(KeywordDetector(keywordDetectionRequest.keyword)) + markDetector


### PR DESCRIPTION
Properly allow cancellation of outdated running filtering when the filters change to avoid having to wait for all the filters to finish before the last one.